### PR TITLE
Fix DiGraph class usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Temporary files
 tmp/**
+
+# Cell libraries
+cell_libraries/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Python bytecode
+*.pyc
+
+# Temporary files
+tmp/**

--- a/CircuitGraph.py
+++ b/CircuitGraph.py
@@ -152,7 +152,7 @@ class CircuitGraph(object):
 				self.__redundant_circuit['wires'][w]['from'],
 				self.__redundant_circuit['wires'][w]['to'])
 
-		isolated_nodes = nx.isolates(self.__redundant_graph)
+		isolated_nodes = list(nx.isolates(self.__redundant_graph))
 		logger.warn('remove isolates: {}'.format(isolated_nodes))
 		self.__redundant_graph.remove_nodes_from(isolated_nodes)
 

--- a/CircuitGraph.py
+++ b/CircuitGraph.py
@@ -163,23 +163,23 @@ class CircuitGraph(object):
 					self.__circuit['cells'][n] = {}
 					self.__circuit['cells'][n]['type'] = node_type
 					self.__graph.add_node(n)
-					self.__graph[n]['node_type'] = node_type
+					self.__graph.nodes()[n]['node_type'] = node_type
 				else:
 					logger.info('port add: skip node {}'.format(n))
 			elif node_type in ('and', 'xor', 'dff', 'dffsr'):
 				self.__circuit['cells'][n] = {}
 				self.__circuit['cells'][n]['type'] = node_type
 				self.__graph.add_node(n)
-				self.__graph[n]['node_type'] = node_type
+				self.__graph.nodes()[n]['node_type'] = node_type
 			elif node_type == 'or':
 				self.__circuit['cells'][n] = {}
 				self.__circuit['cells'][n]['type'] = 'and'
 				self.__graph.add_node(n)
-				self.__graph[n]['node_type'] = node_type
+				self.__graph.nodes()[n]['node_type'] = node_type
 			elif node_type == 'mux':
 				self.__circuit['cells'][n] = {}
 				self.__circuit['cells'][n]['type'] = 'mux'
-				self.__graph.add_node(n, node_type=node_type)
+				self.__graph.nodes()[n]['node_type'] = node_type
 			elif node_type == 'const':
 				pass
 			elif node_type == 'not':
@@ -200,8 +200,8 @@ class CircuitGraph(object):
 				self.__graph.add_edge(*e)
 
 		for n in self.__graph.nodes():
-			s = len(self.__graph.successors(n))
-			p = len(self.__graph.predecessors(n))
+			s = len(list(self.__graph.successors(n)))
+			p = len(list(self.__graph.predecessors(n)))
 			if s == 0 and p == 0:
 				logger.warn('Construct graph: node {} is not connected'.format(n))
 			t = self.__circuit['cells'][n]
@@ -221,21 +221,6 @@ class CircuitGraph(object):
 		dot += '}\n'
 		with open(fname if fname else 'tmp/graph.dot', 'w') as filename:
 			filename.write(dot)
-
-	def get_all_predecessors(self, node):
-		predecessors = []
-		for p in self.__graph.predecessors(node):
-			predecessors.append(p)
-			predecessors += self.get_all_predecessors(p)
-		return set(predecessors)
-
-	def get_all_successors(self, node):
-		successors = []
-		for p in self.__graph.successors(node):
-			if p != 'node_type':
-				successors.append(p)
-				successors += self.get_all_successors(p)
-		return set(successors)
 
 	def get_graph(self):
 		return self.__graph

--- a/IndepChecker.py
+++ b/IndepChecker.py
@@ -18,7 +18,7 @@ class IndepChecker(object):
 
 	def __process_circuit(self):
 		for node in self.__circuit.nodes():
-			node_type = self.__circuit[node]['node_type']
+			node_type = self.__circuit.nodes()[node]['node_type']
 			if node_type == 'port':
 				self.__process_port_gate(node)
 			elif node_type in ('xor', 'xnor'):
@@ -34,7 +34,7 @@ class IndepChecker(object):
 				exit(-1)
 
 	def __process_linear_gate(self, gate):
-		pred = self.__circuit.predecessors(gate)
+		pred = list(self.__circuit.predecessors(gate))
 		if len(pred) == 2:
 			in1, in2 = pred
 			self.__s.add(self.__z3_xor(self.__variables_stable[in1],
@@ -55,7 +55,7 @@ class IndepChecker(object):
 			exit(-1)
 
 	def __process_nonlinear_gate(self, gate):
-		pred = self.__circuit.predecessors(gate)
+		pred = list(self.__circuit.predecessors(gate))
 		if len(pred) == 2:
 			in1, in2 = pred
 			self.__s.add(Or(self.__z3_empty(self.__variables_stable[gate]),
@@ -77,7 +77,7 @@ class IndepChecker(object):
 			exit(-1)
 
 	def __process_not_gate(self, gate):
-		pred = self.__circuit.predecessors(gate)
+		pred = list(self.__circuit.predecessors(gate))
 		if len(pred) == 1:
 			in1 = pred[0]
 			self.__s.add(self.__z3_copy(self.__variables_stable[in1], self.__variables_stable[gate]))
@@ -109,7 +109,7 @@ class IndepChecker(object):
 			self.__s.add(And(lst + [Not(v) for v in neg_lst]))
 
 	def __process_register_gate(self, gate):
-		pred = self.__circuit.predecessors(gate)
+		pred = list(self.__circuit.predecessors(gate))
 		if len(pred) == 1:
 			in1 = pred[0]
 			self.__s.add(self.__z3_copy(self.__variables_stable[in1], self.__variables_stable[gate]))
@@ -130,7 +130,7 @@ class IndepChecker(object):
 		variables_activation = {}
 
 		for node in self.__circuit.nodes():
-			if self.__circuit[node]['node_type'] == 'port':
+			if self.__circuit.nodes()[node]['node_type'] == 'port':
 				for label in self.__labels[str(node)]:
 					variables += [label]
 					label_type = label.split('_')[0]

--- a/Z3Checker.py
+++ b/Z3Checker.py
@@ -25,7 +25,7 @@ class Z3Checker(object):
 		variables_activation = {}
 
 		for node in self.__circuit.nodes():
-			if self.__circuit[node]['node_type'] == 'port':
+			if self.__circuit.nodes()[node]['node_type'] == 'port':
 				for label in self.__labels[str(node)]:
 					variables += [label]
 					label_type = label.split('_')[0]
@@ -83,7 +83,7 @@ class Z3Checker(object):
 
 	def __process_circuit(self):
 		for node in self.__circuit.nodes():
-			node_type = self.__circuit[node]['node_type']
+			node_type = self.__circuit.nodes()[node]['node_type']
 			if node_type == 'port':
 				self.__process_port_gate(node)
 			elif node_type in ('xor', 'xnor'):
@@ -99,7 +99,7 @@ class Z3Checker(object):
 				exit(-1)
 
 	def __process_linear_gate(self, gate):
-		pred = self.__circuit.predecessors(gate)
+		pred = list(self.__circuit.predecessors(gate))
 		if len(pred) == 2:
 			in1, in2 = pred
 			self.__s.add(self.__z3_xor(self.__variables_stable[in1],
@@ -120,7 +120,7 @@ class Z3Checker(object):
 			exit(-1)
 
 	def __process_nonlinear_gate(self, gate):
-		pred = self.__circuit.predecessors(gate)
+		pred = list(self.__circuit.predecessors(gate))
 		if len(pred) == 2:
 			in1, in2 = pred
 			self.__s.add(Or(self.__z3_empty(self.__variables_stable[gate]),
@@ -142,7 +142,7 @@ class Z3Checker(object):
 			exit(-1)
 
 	def __process_not_gate(self, gate):
-		pred = self.__circuit.predecessors(gate)
+		pred = list(self.__circuit.predecessors(gate))
 		if len(pred) == 1:
 			in1 = pred[0]
 			self.__s.add(self.__z3_copy(self.__variables_stable[in1], self.__variables_stable[gate]))
@@ -174,7 +174,7 @@ class Z3Checker(object):
 			self.__s.add(And(lst + [Not(v) for v in neg_lst]))
 
 	def __process_register_gate(self, gate):
-		pred = self.__circuit.predecessors(gate)
+		pred = list(self.__circuit.predecessors(gate))
 		if len(pred) == 1:
 			in1 = pred[0]
 			self.__s.add(self.__z3_copy(self.__variables_stable[in1], self.__variables_stable[gate]))

--- a/helpers.py
+++ b/helpers.py
@@ -1,6 +1,6 @@
 from itertools import combinations, permutations
 from mako.template import Template
-from os import system
+from os import system, listdir, path
 from json import dumps, load
 
 def is_int(s):
@@ -134,10 +134,14 @@ def generate_optimized_labeling(filename):
 		tmp = {** ordinary_labels}
 	return labels
 
-def parse_verilog(verilog_files, top_module, template_file='template/yosys.txt'):
+def parse_verilog(verilog_files, top_module, library=None, template_file='template/yosys.txt'):
 	template = Template(filename=template_file)
 	basename = ''.join(verilog_files.split('.')[:-1])
 	files = verilog_files if type(verilog_files) == list else [verilog_files]
+	if (library):
+		for lib in listdir(library):
+			if lib.endswith(".v"):
+				files.append(path.join(library, lib))
 	yosys_script = template.render(input_files=files, top_module=top_module)
 	with open('tmp/synth.ys', 'w') as filename:
 		filename.write(yosys_script)

--- a/helpers.py
+++ b/helpers.py
@@ -134,7 +134,7 @@ def generate_optimized_labeling(filename):
 		tmp = {** ordinary_labels}
 	return labels
 
-def parse_verilog(verilog_files, top_module, library=None, template_file='template/yosys.txt'):
+def parse_verilog(verilog_files, top_module, library=None, template_file=path.expanduser('~/repos/rebecca/template/yosys.txt')):
 	template = Template(filename=template_file)
 	basename = ''.join(verilog_files.split('.')[:-1])
 	files = verilog_files if type(verilog_files) == list else [verilog_files]

--- a/verify.py
+++ b/verify.py
@@ -40,6 +40,9 @@ if __name__ == '__main__':
 	parser.add_argument('-p', '--parse-verilog', nargs=2,
 		metavar=('<netlist>', '<top module>'),
 		help='parse verilog file and generate labeling template')
+	parser.add_argument('-l', '--library', nargs=1,
+		metavar=('<library dir>'),
+		help='use verilog cell libraries located in library dir')
 	parser.add_argument('-o', '--optimized', action='store_true',
 		help='run verification in parallel')
 	parser.add_argument('-c', '--check', nargs=4, metavar=('<netlist>', '<order>', '<labeling>', '<mode>'),
@@ -48,7 +51,10 @@ if __name__ == '__main__':
 		help='check if a netlist <netlist> is <order>-order independent with the <labeling> as initial labeling')
 	args = vars(parser.parse_args())
 	if args['parse_verilog']:
-		parse_verilog(args['parse_verilog'][0], args['parse_verilog'][1])
+		if args['library']:
+			parse_verilog(args['parse_verilog'][0], args['parse_verilog'][1], args['library'][0])
+		else:	
+			parse_verilog(args['parse_verilog'][0], args['parse_verilog'][1])
 	if args['independence_check']:
 		shares = get_shares(args['independence_check'][2])
 		labels = generate_labeling(args['independence_check'][2])[0]

--- a/verify.py
+++ b/verify.py
@@ -1,4 +1,4 @@
-#!/home/rieyu/projects/masking/bin/python3
+#!/usr/bin/env python3
 
 from argparse import ArgumentParser, FileType
 from helpers import *


### PR DESCRIPTION
## Current problem
The current version of `rebecca` crashes when executing the `verify.py` script.
The issue can be reconstructed following the usage instructions given in the README file for the `--check` and `--independence-check` program flows.  
The problem can be traced back to serveral accesses on the `DiGraph` class implemented in the `networkx` package.
It is most likely that the errors are based on an incompatible upgrade of this package to the current version of `rebecca`.

## Solution
The bugs have been fixed by adjusting the member variable and function calls to the newest version of the `networkx.DiGraph` module.
The application now works as expected using the newest version of `networkx` and Python 3.8.

## Further changes
- [Cell library parsing is now supported.](https://github.com/niklasent/rebecca/pull/1)
- A `.gitignore` file has been added for your convenience. :-)